### PR TITLE
conditionally write critical css from multiple urls

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+LOCATION=/output

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
-- name: Build and run
-  uses: docker/build-push-action@v2.2.2
-  on: push
-  runs-on: ubuntu-latest
-  run: URL=https://www.google.com/ docker-compose up
+name: Docker Compose Actions Workflow
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and run
+        run: URL=https://www.google.com/  docker-compose up

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,5 @@
+- name: Build and run
+  uses: docker/build-push-action@v2.2.2
+  on: push
+  runs-on: ubuntu-latest
+  run: URL=https://www.google.com/ docker-compose up

--- a/critical.js
+++ b/critical.js
@@ -17,17 +17,12 @@ const generateCritical = async (url, size, location) => {
     rebase: false,
     minify: true,
     src: url,
-    target: {
-      css: __dirname + `${location}/critical.css`,
-    },
     penthouse: {
       timeout: 40000,
       pageLoadSkipTimeout: 30000,
     },
     dimensions,
   });
-
-  console.log(`Done. critical.css saved in ${location}/critical.css `);
   return css;
 };
 

--- a/index.js
+++ b/index.js
@@ -8,9 +8,11 @@ const makeDir = require("make-dir");
 const { promisify } = require("util");
 const writeFileAsync = promisify(fs.writeFile);
 
-const url = process.env.URL;
+const urls = process.env.URL;
 const dimensions = process.env.DIMENSIONS || "1300x900";
 const location = process.env.LOCATION || "/output";
+const urlArray = urls.split(",");
+let counter = 1;
 
 async function outputFileAsync(file, data) {
   const dir = path.join(__dirname, file);
@@ -19,21 +21,32 @@ async function outputFileAsync(file, data) {
     await makeDir(dir);
   }
 
-  return writeFileAsync(`${dir}/critical.css`, data);
+  return writeFileAsync(`${dir}/critical-${counter}.css`, data);
 }
 
-generator
-  .generateCritical(url, dimensions, location)
-  .then((css) => {
-    console.log(css);
-    if (css.length > 10)
-      outputFileAsync(location, css).then(() =>
-        console.log(`Done. critical.css saved in ${location}/critical.css `)
-      );
-    else console.log("Invalid css generated! Please try with different URL");
-  })
-  .catch((err) => {
-    // console.error(err);
-    console.error(err.name);
-    console.error(err.message);
-  });
+const extractor = async () => {
+  const singleUrl = urlArray.pop();
+  if (!singleUrl) {
+    return Promise.resolve();
+  }
+  return generator
+    .generateCritical(singleUrl, dimensions, location)
+    .then(async (css) => {
+      if (css.length > 10) {
+        await outputFileAsync(location, css).then(() =>
+          console.log(
+            `Done. critical-${counter}.css saved in ${location}/critical-${counter}.css `
+          )
+        );
+        counter++;
+        return urlArray.length > 0 && extractor();
+      } else
+        console.log("Invalid css generated! Please try with different URL");
+    })
+    .catch((err) => {
+      // console.error(err);
+      console.error(err.name);
+      console.error(err.message);
+    });
+};
+extractor();

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ async function outputFileAsync(file, data) {
 generator
   .generateCritical(url, dimensions, location)
   .then((css) => {
-    //console.log(css);
+    console.log(css);
     if (css.length > 10)
       outputFileAsync(location, css).then(() =>
         console.log(`Done. critical.css saved in ${location}/critical.css `)

--- a/index.js
+++ b/index.js
@@ -2,13 +2,36 @@
 
 "use strict";
 const generator = require("./critical");
+const path = require("path");
+const fs = require("fs");
+const makeDir = require("make-dir");
+const { promisify } = require("util");
+const writeFileAsync = promisify(fs.writeFile);
+
 const url = process.env.URL;
 const dimensions = process.env.DIMENSIONS || "1300x900";
 const location = process.env.LOCATION || "/output";
 
+async function outputFileAsync(file, data) {
+  const dir = path.join(__dirname, file);
+
+  if (!fs.existsSync(dir)) {
+    await makeDir(dir);
+  }
+
+  return writeFileAsync(`${dir}/critical.css`, data);
+}
+
 generator
   .generateCritical(url, dimensions, location)
-  .then((css) => console.log(css))
+  .then((css) => {
+    //console.log(css);
+    if (css.length > 10)
+      outputFileAsync(location, css).then(() =>
+        console.log(`Done. critical.css saved in ${location}/critical.css `)
+      );
+    else console.log("Invalid css generated! Please try with different URL");
+  })
   .catch((err) => {
     // console.error(err);
     console.error(err.name);


### PR DESCRIPTION
Use `node.js` to write css to file. We also let critical do this, but we cannot handle error detection and thus generating an empty css file sometimes.